### PR TITLE
Upgrade lz4 to v2.0.7, fix stream close regression

### DIFF
--- a/chains.go
+++ b/chains.go
@@ -11,10 +11,22 @@ import (
 	"github.com/pkg/errors"
 )
 
+var compressionLevel = 10
+
+// SetCompressionLevel allows you to set LZ4 compression level used for chunks
+func SetCompressionLevel(level int) {
+	compressionLevel = level
+}
+
 func chainCompressor(w io.Writer) (*lz4.Writer, error) {
 	zw := lz4.NewWriter(w)
-	zw.Header.HighCompression = true
+	zw.Header.CompressionLevel = compressionLevel
 	return zw, nil
+}
+
+func chainDecompressor(r io.Reader) (io.Reader, error) {
+	zr := lz4.NewReader(r)
+	return zr, nil
 }
 
 func chainDecryptor(key []byte, src io.Reader) (io.Reader, error) {

--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,7 @@ require (
 	github.com/abdullin/mdb v0.0.0-20171224093530-b63d30c6dad8
 	github.com/bmatsuo/lmdb-go v1.8.0
 	github.com/golang/protobuf v1.2.0
-	github.com/pierrec/lz4 v1.0.1
+	github.com/pierrec/lz4 v0.0.0-20181005164709-635575b42742
 	github.com/pierrec/xxHash v0.1.1 // indirect
 	github.com/pkg/errors v0.8.0
 )

--- a/go.sum
+++ b/go.sum
@@ -6,6 +6,8 @@ github.com/bmatsuo/lmdb-go v1.8.0 h1:ohf3Q4xjXZBKh4AayUY4bb2CXuhRAI8BYGlJq08EfNA
 github.com/bmatsuo/lmdb-go v1.8.0/go.mod h1:wWPZmKdOAZsl4qOqkowQ1aCrFie1HU8gWloHMCeAUdM=
 github.com/golang/protobuf v1.2.0 h1:P3YflyNX/ehuJFLhxviNdFxQPkGK5cDcApsge1SqnvM=
 github.com/golang/protobuf v1.2.0/go.mod h1:6lQm79b+lXiMfvg/cZm0SGofjICqVBUtrP5yJMmIC1U=
+github.com/pierrec/lz4 v0.0.0-20181005164709-635575b42742 h1:wKfigKMTgvSzBLIVvB5QaBBQI0odU6n45/UKSphjLus=
+github.com/pierrec/lz4 v0.0.0-20181005164709-635575b42742/go.mod h1:3/3N9NVKO0jef7pBehbT1qWhCMrIgbYNnFAZCqQ5LRc=
 github.com/pierrec/lz4 v1.0.1 h1:w6GMGWSsCI04fTM8wQRdnW74MuJISakuUU0onU0TYB4=
 github.com/pierrec/lz4 v1.0.1/go.mod h1:pdkljMzZIN41W+lC3N2tnIh5sFi+IEE17M5jbnwPHcY=
 github.com/pierrec/lz4 v2.0.5+incompatible h1:2xWsjqPFWcplujydGg4WmhC/6fZqK42wMM8aXeqhl0I=
@@ -14,3 +16,4 @@ github.com/pierrec/xxHash v0.1.1 h1:KP4NrV9023xp3M4FkTYfcXqWigsOCImL1ANJ7sh5vg4=
 github.com/pierrec/xxHash v0.1.1/go.mod h1:w2waW5Zoa/Wc4Yqe0wgrIYAGKqRMf7czn2HNKXmuL+I=
 github.com/pkg/errors v0.8.0 h1:WdK/asTD0HN+q6hsWO3/vpuAkAr+tw6aNJNDFFf0+qw=
 github.com/pkg/errors v0.8.0/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
+github.com/pkg/profile v1.2.1/go.mod h1:hJw3o1OdXxsrSjjVksARp5W95eeEaEfptyVZyv6JUPA=

--- a/lmdb.go
+++ b/lmdb.go
@@ -53,7 +53,7 @@ func lmdbAddChunk(tx *mdb.Tx, chunkStartPos int64, dto *ChunkDto) error {
 		return errors.Wrap(err, "PutProto")
 	}
 
-	log.Printf("Added chunk %s with %d records and %d bytes", dto.FileName, dto.Records, dto.UncompressedByteSize)
+	log.Printf("Added chunk %s with %d records and %d bytes (%d compressed)", dto.FileName, dto.Records, dto.UncompressedByteSize, dto.CompressedDiskSize)
 	return nil
 }
 


### PR DESCRIPTION
Now you should be able to pick LZ4 compression level by using
cellar.SetCompressionLevel (defaults to 10)

Fixes #5